### PR TITLE
Add support for --output and --timeout flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,17 +19,19 @@ Usage:
   wms-tiles-downloader get [flags]
 
 Flags:
-  -b, --bbox float64Slice   comma-separated list of bbox coords (default [])
-      --concurrency int     limit of concurrent requests to the WMS server (default 16)
-      --format string       tile format (default "image/png")
-      --height int          tile height (default 256)
+  -b, --bbox float64Slice   Comma-separated list of bbox coords (default [])
+      --concurrency int     Limit of concurrent requests to the WMS server (default 16)
+      --format string       Tile format (default "image/png")
+      --height int          Tile height (default 256)
   -h, --help                help for get
-  -l, --layer string        layer name
-  -s, --style string        layer style
+  -l, --layer string        Layer name
+  -o, --output string       Output directory for downloaded tiles
+  -s, --style string        Layer style
+  -t, --timeout int         HTTP request timeout (in milliseconds) (default 10000)
   -u, --url string          WMS server url
       --version string      WMS server version (default "1.3.0")
-      --width int           lile width (default 256)
-  -z, --zoom ints           comma-separated list of zooms
+      --width int           Tile width (default 256)
+  -z, --zoom ints           Comma-separated list of zooms
 ```
 
 ### Examples

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -67,6 +67,14 @@ var getCmd = &cobra.Command{
 		if err != nil {
 			fmt.Printf("ERR: %s\n", err)
 		}
+		output, err := cmd.Flags().GetString("output")
+		if err != nil {
+			fmt.Printf("ERR: %s\n", err)
+		}
+		timeout, err := cmd.Flags().GetInt("timeout")
+		if err != nil {
+			fmt.Printf("ERR: %s\n", err)
+		}
 		for _, tileID := range tileIDs {
 			sem <- true
 			go func(tileID mercantile.TileID) {
@@ -75,11 +83,13 @@ var getCmd = &cobra.Command{
 				tile, err := WMSClient.GetTile(
 					ctx,
 					tileID,
+					timeout,
 					wms.WithLayers(layer),
 					wms.WithStyles(style),
 					wms.WithWidth(width),
 					wms.WithHeight(height),
 					wms.WithFormat(format),
+					wms.WithOutputDir(output),
 				)
 				if err != nil {
 					fmt.Printf("ERR: %s\n", err)
@@ -135,6 +145,12 @@ func init() {
 	)
 	getCmd.Flags().String(
 		"version", "1.3.0", "WMS server version",
+	)
+	getCmd.Flags().StringP(
+		"output", "o", "", "Output directory for downloaded tiles",
+	)
+	getCmd.Flags().IntP(
+		"timeout", "t", 10000, "HTTP request timeout (in milliseconds)",
 	)
 	getCmd.Flags().Int(
 		"concurrency", 16, "Limit of concurrent requests to the WMS server",

--- a/wms/client_test.go
+++ b/wms/client_test.go
@@ -126,7 +126,7 @@ func TestClient_GetTile(t *testing.T) {
 			transport.RegisterResponder(http.MethodGet, "", test.Resp)
 
 			tileID := mercantile.TileID{X: 17, Y: 10, Z: 5}
-			tile, err := WMSClient.GetTile(context.Background(), tileID)
+			tile, err := WMSClient.GetTile(context.Background(), tileID, 10000)
 
 			assert.Equal(t, test.ExpectedError, err)
 			if err != nil {

--- a/wms/tile.go
+++ b/wms/tile.go
@@ -4,19 +4,22 @@ import (
 	"fmt"
 	"github.com/lmikolajczak/wms-tiles-downloader/mercantile"
 	"net/url"
+	"path"
+	"path/filepath"
 	"strconv"
 )
 
 type Tile struct {
-	id     mercantile.TileID
-	name   string
-	path   string
-	body   []byte
-	layers string
-	styles string
-	format string
-	width  int
-	height int
+	id        mercantile.TileID
+	name      string
+	path      string
+	body      []byte
+	layers    string
+	styles    string
+	format    string
+	width     int
+	height    int
+	outputdir string
 }
 
 type TileOption func(t *Tile)
@@ -48,6 +51,15 @@ func WithWidth(width int) TileOption {
 func WithHeight(height int) TileOption {
 	return func(t *Tile) {
 		t.height = height
+	}
+}
+
+func WithOutputDir(dir string) TileOption {
+	if !path.IsAbs(dir) {
+		dir, _ = filepath.Abs(dir)
+	}
+	return func(t *Tile) {
+		t.outputdir = dir
 	}
 }
 

--- a/wms/tile_test.go
+++ b/wms/tile_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"github.com/lmikolajczak/wms-tiles-downloader/mercantile"
 	"github.com/stretchr/testify/assert"
+	"os"
+	"path"
 	"testing"
 )
 
@@ -45,6 +47,36 @@ func TestWithHeight(t *testing.T) {
 	WithHeight(expected)(tile)
 
 	assert.Equal(t, expected, tile.height)
+}
+
+func TestWithOutputDir(t *testing.T) {
+	cwd, _ := os.Getwd()
+	tests := map[string]struct {
+		OutputDir string
+		Expected  string
+	}{
+		"no output path provided - use current working directory": {
+			OutputDir: "",
+			Expected:  cwd,
+		},
+		"relative output path provided": {
+			OutputDir: "path/wms-tiles-downloader",
+			Expected:  path.Join(cwd, "path/wms-tiles-downloader"),
+		},
+		"absolute output path provided": {
+			OutputDir: "/path/tiles",
+			Expected:  "/path/tiles",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			tile := &Tile{}
+			WithOutputDir(test.OutputDir)(tile)
+
+			assert.Equal(t, test.Expected, tile.outputdir)
+		})
+	}
 }
 
 func TestTile_Name(t *testing.T) {


### PR DESCRIPTION
Per request in: https://github.com/lmikolajczak/wms-tiles-downloader/issues/7

* Added `--output` flag that allows to specify output directory for downloaded tiles
* Added `--timeout` flag that allows to specify http request timeout (in milliseconds) and increased default value from 5 seconds to 10 seconds