### PR TITLE
Fix dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /code
 
 # Pre-copy/cache go.mod for pre-downloading dependencies and only redownloading them
 # in subsequent builds if they change.
-COPY go.mod go.sum* .
+COPY go.mod go.sum* ./
 RUN go mod download && go mod verify
 
 CMD tail -f /dev/null


### PR DESCRIPTION
Fix docker build error by adding a `/` to the COPY destination

```
Step 3/5 : COPY go.mod go.sum* .
When using COPY with more than one source file, the destination must be a directory and end with a /
```