### PR TITLE
Add query string params support and make baseURL required

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,23 +16,23 @@ Go will automatically install it in your $GOPATH/bin directory which should be i
 Download tiles from WMS server based on provided options.
 
 Usage:
-wms-tiles-downloader get [flags]
+    wms-tiles-downloader get [flags]
 
 Flags:
--b, --bbox float64Slice       Comma-separated list of bbox coords (default [])
-    --concurrency int         Limit of concurrent requests to the WMS server (default 16)
-    --format string           Tile format (default "image/png")
-    --height int              Tile height (default 256)
--h, --help                    Help for get
--l, --layer string            Layer name
--o, --output string           Output directory for downloaded tiles
-    --params stringToString   Custom query string params (default [])
--s, --style string            Layer style
--t, --timeout int             HTTP request timeout (in milliseconds) (default 10000)
--u, --url string              WMS server url
-    --version string          WMS server version (default "1.3.0")
-    --width int               Tile width (default 256)
--z, --zoom ints               Comma-separated list of zooms
+    -b, --bbox float64Slice       Comma-separated list of bbox coords (default [])
+        --concurrency int         Limit of concurrent requests to the WMS server (default 16)
+        --format string           Tile format (default "image/png")
+        --height int              Tile height (default 256)
+    -h, --help                    Help for get
+    -l, --layer string            Layer name
+    -o, --output string           Output directory for downloaded tiles
+        --params stringToString   Custom query string params (default [])
+    -s, --style string            Layer style
+    -t, --timeout int             HTTP request timeout (in milliseconds) (default 10000)
+    -u, --url string              WMS server url
+        --version string          WMS server version (default "1.3.0")
+        --width int               Tile width (default 256)
+    -z, --zoom ints               Comma-separated list of zooms
 ```
 
 ### Examples

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Command line application for downloading map tiles from given WMS server.
 ### Installation
 
 ```
-go install github.com/lmikolajczak/wms-tiles-downloader@v0.2.1
+go install github.com/lmikolajczak/wms-tiles-downloader@v0.3.0
 ```
 
 Go will automatically install it in your $GOPATH/bin directory which should be in your $PATH.
@@ -77,5 +77,5 @@ root@df62f3f34fef:/tiles# tree
 ### Alternative - use as a library ([pkg.go.dev](https://pkg.go.dev/github.com/lmikolajczak/wms-tiles-downloader/wms))
 
 ```
-go get github.com/lmikolajczak/wms-tiles-downloader@v0.2.1
+go get github.com/lmikolajczak/wms-tiles-downloader@v0.3.0
 ```

--- a/README.md
+++ b/README.md
@@ -16,22 +16,23 @@ Go will automatically install it in your $GOPATH/bin directory which should be i
 Download tiles from WMS server based on provided options.
 
 Usage:
-  wms-tiles-downloader get [flags]
+wms-tiles-downloader get [flags]
 
 Flags:
-  -b, --bbox float64Slice   Comma-separated list of bbox coords (default [])
-      --concurrency int     Limit of concurrent requests to the WMS server (default 16)
-      --format string       Tile format (default "image/png")
-      --height int          Tile height (default 256)
-  -h, --help                help for get
-  -l, --layer string        Layer name
-  -o, --output string       Output directory for downloaded tiles
-  -s, --style string        Layer style
-  -t, --timeout int         HTTP request timeout (in milliseconds) (default 10000)
-  -u, --url string          WMS server url
-      --version string      WMS server version (default "1.3.0")
-      --width int           Tile width (default 256)
-  -z, --zoom ints           Comma-separated list of zooms
+-b, --bbox float64Slice       Comma-separated list of bbox coords (default [])
+    --concurrency int         Limit of concurrent requests to the WMS server (default 16)
+    --format string           Tile format (default "image/png")
+    --height int              Tile height (default 256)
+-h, --help                    Help for get
+-l, --layer string            Layer name
+-o, --output string           Output directory for downloaded tiles
+    --params stringToString   Custom query string params (default [])
+-s, --style string            Layer style
+-t, --timeout int             HTTP request timeout (in milliseconds) (default 10000)
+-u, --url string              WMS server url
+    --version string          WMS server version (default "1.3.0")
+    --width int               Tile width (default 256)
+-z, --zoom ints               Comma-separated list of zooms
 ```
 
 ### Examples

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -36,7 +36,10 @@ var getCmd = &cobra.Command{
 		if err != nil {
 			fmt.Printf("ERR: %s\n", err)
 		}
-		WMSClient := wms.NewClient(wms.WithBaseURL(url), wms.WithVersion(version))
+		WMSClient, err := wms.NewClient(url, wms.WithVersion(version))
+		if err != nil {
+			fmt.Printf("ERR: %s\n", err)
+		}
 
 		// Use semaphore pattern to limit concurrency. We don't want to flood WMS
 		// server with too many requests.

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -32,11 +32,15 @@ var getCmd = &cobra.Command{
 		if err != nil {
 			fmt.Printf("ERR: %s\n", err)
 		}
+		params, err := cmd.Flags().GetStringToString("params")
+		if err != nil {
+			fmt.Printf("ERR: %s\n", err)
+		}
 		version, err := cmd.Flags().GetString("version")
 		if err != nil {
 			fmt.Printf("ERR: %s\n", err)
 		}
-		WMSClient, err := wms.NewClient(url, wms.WithVersion(version))
+		WMSClient, err := wms.NewClient(url, wms.WithQueryString(params), wms.WithVersion(version))
 		if err != nil {
 			fmt.Printf("ERR: %s\n", err)
 		}
@@ -157,5 +161,8 @@ func init() {
 	)
 	getCmd.Flags().Int(
 		"concurrency", 16, "Limit of concurrent requests to the WMS server",
+	)
+	getCmd.Flags().StringToString(
+		"params", nil, "Custom query string params",
 	)
 }

--- a/wms/client.go
+++ b/wms/client.go
@@ -26,6 +26,7 @@ type Client struct {
 	service          string
 	requestType      string
 	spatialRefSystem string
+	queryStrings     map[string]string
 }
 
 type ClientOption func(c *Client)
@@ -45,6 +46,12 @@ func WithBaseURL(baseUrl string) ClientOption {
 func WithVersion(version string) ClientOption {
 	return func(c *Client) {
 		c.version = version
+	}
+}
+
+func WithQueryString(qs map[string]string) ClientOption {
+	return func(c *Client) {
+		c.queryStrings = qs
 	}
 }
 
@@ -79,6 +86,11 @@ func (c *Client) BaseURL() string {
 	} else {
 		params.Add("srs", c.spatialRefSystem)
 	}
+	
+	for name, param := range c.queryStrings {
+		params.Add(name, param)
+	}
+
 	u.RawQuery = params.Encode()
 
 	return u.String()

--- a/wms/client.go
+++ b/wms/client.go
@@ -2,6 +2,7 @@ package wms
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"github.com/lmikolajczak/wms-tiles-downloader/mercantile"
 	"io/ioutil"
@@ -37,12 +38,6 @@ func WithHTTPClient(httpClient *http.Client) ClientOption {
 	}
 }
 
-func WithBaseURL(baseUrl string) ClientOption {
-	return func(c *Client) {
-		c.baseURL = baseUrl
-	}
-}
-
 func WithVersion(version string) ClientOption {
 	return func(c *Client) {
 		c.version = version
@@ -55,9 +50,14 @@ func WithQueryString(qs map[string]string) ClientOption {
 	}
 }
 
-func NewClient(options ...ClientOption) *Client {
+func NewClient(baseURL string, options ...ClientOption) (*Client, error) {
+	if baseURL == "" {
+		return nil, errors.New("baseURL is required")
+	}
+
 	c := &Client{
 		httpClient:       http.DefaultClient,
+		baseURL:          baseURL,
 		version:          v1_3_0,
 		service:          "WMS",
 		requestType:      "GetMap",
@@ -68,7 +68,7 @@ func NewClient(options ...ClientOption) *Client {
 		option(c)
 	}
 
-	return c
+	return c, nil
 }
 
 func (c *Client) BaseURL() string {
@@ -86,7 +86,7 @@ func (c *Client) BaseURL() string {
 	} else {
 		params.Add("srs", c.spatialRefSystem)
 	}
-	
+
 	for name, param := range c.queryStrings {
 		params.Add(name, param)
 	}

--- a/wms/client_test.go
+++ b/wms/client_test.go
@@ -10,83 +10,69 @@ import (
 	"testing"
 )
 
-func TestWithHTTPClient(t *testing.T) {
-	c := &Client{}
-	expected := &http.Client{}
-	WithHTTPClient(expected)(c)
-
-	assert.Equal(t, expected, c.httpClient)
-}
-
-func TestWithBaseURL(t *testing.T) {
-	c := &Client{}
-	expected := "https://wms.server.url"
-	WithBaseURL(expected)(c)
-
-	assert.Equal(t, expected, c.baseURL)
-}
-
-func TestWithVersion(t *testing.T) {
-	c := &Client{}
-	expected := v1_1_1
-	WithVersion(expected)(c)
-
-	assert.Equal(t, expected, c.version)
-}
-
 func TestClient_BaseURL(t *testing.T) {
 	tests := map[string]struct {
 		BaseURL      string
 		Version      string
-		Expected     string
 		QueryStrings map[string]string
+		Want         string
+		WantErr      error
 	}{
 		"Get base URL for WMS v1.3.0": {
-			BaseURL:  "https://wms.service.com",
-			Version:  v1_3_0,
-			Expected: "https://wms.service.com?crs=EPSG%3A3857&request=GetMap&service=WMS&version=1.3.0",
+			BaseURL: "https://wms.service.com",
+			Version: v1_3_0,
+			Want:    "https://wms.service.com?crs=EPSG%3A3857&request=GetMap&service=WMS&version=1.3.0",
 		},
 		"Get base URL for WMS v1.1.1": {
-			BaseURL:  "https://wms.service.com",
-			Version:  v1_1_1,
-			Expected: "https://wms.service.com?request=GetMap&service=WMS&srs=EPSG%3A3857&version=1.1.1",
+			BaseURL: "https://wms.service.com",
+			Version: v1_1_1,
+			Want:    "https://wms.service.com?request=GetMap&service=WMS&srs=EPSG%3A3857&version=1.1.1",
 		},
 		"Get base URL for WMS v1.1.0": {
-			BaseURL:  "https://wms.service.com",
-			Version:  v1_1_0,
-			Expected: "https://wms.service.com?request=GetMap&service=WMS&srs=EPSG%3A3857&version=1.1.0",
+			BaseURL: "https://wms.service.com",
+			Version: v1_1_0,
+			Want:    "https://wms.service.com?request=GetMap&service=WMS&srs=EPSG%3A3857&version=1.1.0",
 		},
 		"Get base URL for WMS v1.0.0": {
-			BaseURL:  "https://wms.service.com",
-			Version:  v1_0_0,
-			Expected: "https://wms.service.com?request=GetMap&service=WMS&srs=EPSG%3A3857&version=1.0.0",
+			BaseURL: "https://wms.service.com",
+			Version: v1_0_0,
+			Want:    "https://wms.service.com?request=GetMap&service=WMS&srs=EPSG%3A3857&version=1.0.0",
 		},
 		"Set HTTPS if scheme is missing": {
-			BaseURL:  "wms.service.com",
-			Version:  v1_3_0,
-			Expected: "https://wms.service.com?crs=EPSG%3A3857&request=GetMap&service=WMS&version=1.3.0",
+			BaseURL: "wms.service.com",
+			Version: v1_3_0,
+			Want:    "https://wms.service.com?crs=EPSG%3A3857&request=GetMap&service=WMS&version=1.3.0",
 		},
 		"Set query string params if provided": {
 			BaseURL:      "wms.service.com",
 			Version:      v1_3_0,
-			Expected:     "https://wms.service.com?crs=EPSG%3A3857&key=value&request=GetMap&service=WMS&version=1.3.0",
+			Want:         "https://wms.service.com?crs=EPSG%3A3857&key=value&request=GetMap&service=WMS&version=1.3.0",
 			QueryStrings: map[string]string{"key": "value"},
 		},
 		"Do not override HTTP": {
-			BaseURL:  "http://wms.service.com",
-			Version:  v1_3_0,
-			Expected: "http://wms.service.com?crs=EPSG%3A3857&request=GetMap&service=WMS&version=1.3.0",
+			BaseURL: "http://wms.service.com",
+			Version: v1_3_0,
+			Want:    "http://wms.service.com?crs=EPSG%3A3857&request=GetMap&service=WMS&version=1.3.0",
+		},
+		"BaseURL is required": {
+			BaseURL: "",
+			Version: v1_0_0,
+			WantErr: errors.New("baseURL is required"),
 		},
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			c := NewClient(
-				WithBaseURL(test.BaseURL),
+			client, err := NewClient(
+				test.BaseURL,
 				WithVersion(test.Version),
 				WithQueryString(test.QueryStrings),
 			)
-			assert.Equal(t, test.Expected, c.BaseURL())
+			if err != nil {
+				testErrorMessage(t, err, test.WantErr)
+			} else {
+				assert.Equal(t, test.Want, client.BaseURL())
+			}
 		})
 	}
 }
@@ -123,18 +109,21 @@ func TestClient_GetTile(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			transport := httpmock.NewMockTransport()
-			WMSClient := NewClient(
-				WithBaseURL(test.BaseURL),
+			client, err := NewClient(
+				test.BaseURL,
 				WithHTTPClient(
 					&http.Client{
 						Transport: transport,
 					},
 				),
 			)
+			if err != nil {
+				t.Fatalf("err = %v; want: nil", err)
+			}
 			transport.RegisterResponder(http.MethodGet, "", test.Resp)
 
 			tileID := mercantile.TileID{X: 17, Y: 10, Z: 5}
-			tile, err := WMSClient.GetTile(context.Background(), tileID, 10000)
+			tile, err := client.GetTile(context.Background(), tileID, 10000)
 
 			assert.Equal(t, test.ExpectedError, err)
 			if err != nil {
@@ -146,18 +135,17 @@ func TestClient_GetTile(t *testing.T) {
 	}
 }
 
-func TestNewClient(t *testing.T) {
-	expectedClient := &http.Client{}
-	expectedBaseURL := "https://wms.server.url"
-	expectedVersion := v1_3_0
-
-	c := NewClient(
-		WithHTTPClient(expectedClient),
-		WithBaseURL(expectedBaseURL),
-		WithVersion(expectedVersion),
-	)
-
-	assert.Equal(t, expectedClient, c.httpClient)
-	assert.Equal(t, expectedBaseURL, c.baseURL)
-	assert.Equal(t, expectedVersion, c.version)
+func testErrorMessage(t *testing.T, err error, want error) {
+	t.Helper()
+	if err != nil && want == nil {
+		t.Errorf("error message: %s; want: nil", err.Error())
+	}
+	if err == nil && want != nil {
+		t.Errorf("error message: nil; want: %s", want.Error())
+	}
+	if err != nil && want != nil {
+		if got := err.Error(); got != want.Error() {
+			t.Errorf("error message: %s; want: %s", got, want)
+		}
+	}
 }

--- a/wms/client_test.go
+++ b/wms/client_test.go
@@ -36,9 +36,10 @@ func TestWithVersion(t *testing.T) {
 
 func TestClient_BaseURL(t *testing.T) {
 	tests := map[string]struct {
-		BaseURL  string
-		Version  string
-		Expected string
+		BaseURL      string
+		Version      string
+		Expected     string
+		QueryStrings map[string]string
 	}{
 		"Get base URL for WMS v1.3.0": {
 			BaseURL:  "https://wms.service.com",
@@ -65,6 +66,12 @@ func TestClient_BaseURL(t *testing.T) {
 			Version:  v1_3_0,
 			Expected: "https://wms.service.com?crs=EPSG%3A3857&request=GetMap&service=WMS&version=1.3.0",
 		},
+		"Set query string params if provided": {
+			BaseURL:      "wms.service.com",
+			Version:      v1_3_0,
+			Expected:     "https://wms.service.com?crs=EPSG%3A3857&key=value&request=GetMap&service=WMS&version=1.3.0",
+			QueryStrings: map[string]string{"key": "value"},
+		},
 		"Do not override HTTP": {
 			BaseURL:  "http://wms.service.com",
 			Version:  v1_3_0,
@@ -77,6 +84,7 @@ func TestClient_BaseURL(t *testing.T) {
 			c := NewClient(
 				WithBaseURL(test.BaseURL),
 				WithVersion(test.Version),
+				WithQueryString(test.QueryStrings),
 			)
 			assert.Equal(t, test.Expected, c.BaseURL())
 		})

--- a/wms/example_newclient_test.go
+++ b/wms/example_newclient_test.go
@@ -3,10 +3,13 @@ package wms
 import "fmt"
 
 func ExampleNewClient() {
-	client := NewClient(
-		WithBaseURL("wms.server.url"),
+	client, err := NewClient(
+		"wms.server.url",
 		WithVersion("1.3.0"),
 	)
+	if err != nil {
+		fmt.Println(err)
+	}
 	fmt.Printf("client.BaseURL() = %s, ", client.BaseURL())
 	// Output:
 	// client.BaseURL() = https://wms.server.url?crs=EPSG%3A3857&request=GetMap&service=WMS&version=1.3.0,


### PR DESCRIPTION
Within this PR, following changes/improvements have been added:

- It's possible to use custom query string params that will be included in every request to the web map server
- `--params` flag has been added to the `get` CLI command
- `baseURL` is now required when initialising the WMS client
- Tests have been adjusted to cover new features and use cases
- README.md has been updated